### PR TITLE
Add Dockerfile and instructions for using it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Dockerfile to setup and run the Cascade toolbox for Calibrated spike inference from calcium imaging data in a Docker container
+# Repository: https://github.com/HelmchenLabSoftware/Cascade
+# See README_Docker.md for instructions
+
+
+ARG BASE_CONTAINER=jupyter/scipy-notebook
+FROM $BASE_CONTAINER
+
+LABEL maintainer="Henry Luetcke <hluetcke@ethz.ch>"
+
+# install the Python dependencies
+COPY requirements_mac.txt environment_mac.yml /tmp/
+RUN conda env update -q -f /tmp/environment_mac.yml && \
+	pip install --quiet --no-cache-dir -r /tmp/requirements_mac.txt && \
+	conda clean -y --all && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"

--- a/README_Docker.md
+++ b/README_Docker.md
@@ -1,0 +1,9 @@
+## How to run Cascade in a Docker container
+
+1. Make sure you have [Docker](https://www.docker.com/) installed
+2. Download / clone the repository to your local computer
+3. Set working directory of your shell / terminal to the repository
+4. Build the container: `docker build -t cascade-notebook .` (this will take a while)
+5. Run the container: `docker run -p 8888:8888 -v "$PWD":/home/jovyan/work cascade-notebook`
+6. Open the Jupyter notebook server by pasting the URL in the output of the previous command into your browser, e.g. http://127.0.0.1:8888/?token=dfa6fcaf7c53c104dfdfdeffaaf3e487b355edb
+The repository folder is mounted in the container and changes are persistent.


### PR DESCRIPTION
I created a Dockerfile for running the toolbox in a container. There is also a README_Docker.md with instructions. I would keep this separate from the standard instructions for now, as it requires some familiarity with Docker. 